### PR TITLE
Fix view and faker class errors

### DIFF
--- a/resources/views/compensation_preview.blade.php
+++ b/resources/views/compensation_preview.blade.php
@@ -400,9 +400,9 @@
                     @endif
                     <div>
                         <label class="font-semibold text-gray-700">দখল উল্লেখ করা আছে কিনা:</label>
-                        <p class="text-gray-900">{{ $deed['possession_mentioned'] === 'yes' ? 'হ্যাঁ' : 'না' }}</p>
+                        <p class="text-gray-900">{{ ($deed['possession_mentioned'] ?? 'no') === 'yes' ? 'হ্যাঁ' : 'না' }}</p>
                     </div>
-                    @if($deed['possession_mentioned'] === 'yes')
+                    @if(($deed['possession_mentioned'] ?? 'no') === 'yes')
                     <div>
                         <label class="font-semibold text-gray-700">দখলের দাগ নম্বর:</label>
                         <p class="text-gray-900">{{ $deed['possession_plot_no'] ?? '' }}</p>


### PR DESCRIPTION
Fixes "Undefined array key 'possession_mentioned'" by adding null coalescing operators in `compensation_preview.blade.php`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0e5b057-f831-456e-8405-5029e52b0927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0e5b057-f831-456e-8405-5029e52b0927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

